### PR TITLE
Safety enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The TLS versions in use are TLS1.2 and TLS1.3. Implementations pick the highest 
 supported by both sender and receiver.
 
 TLS certificates are generated and used on both sides of the connection to
-establish a mutual TLS (mTLS) connection: the sender verifies the sender, and
+establish a mutual TLS (mTLS) connection: the sender verifies the receiver, and
 the receiver verifies the sender. 
 
 Certificate are generated and used per session, being discarded when a session ends.

--- a/README.md
+++ b/README.md
@@ -55,12 +55,15 @@ QR payload:
 
 ```json5
 {
-  ip_address: String,
+  ip_address: [String, ..., ..., String],
   port: Number,
   certificate_hash: String,
   pin: String
 }
 ```
+
+**Note:** `ip_address` is a list of strings, as the receiver may have many different local IP
+addresses.
 
 ### 2.2- Manual authentication (Fallback Method)
 

--- a/README.md
+++ b/README.md
@@ -38,18 +38,32 @@ Nearby Sharing in Tella was designed for contexts of repression and surveillance
 The TLS versions in use are TLS1.2 and TLS1.3. Implementations pick the highest version
 supported by both sender and receiver.
 
+TLS certificates are generated and used on both sides of the connection to
+establish a mutual TLS (mTLS) connection: the sender verifies the sender, and
+the receiver verifies the sender. 
+
+Certificate are generated and used per session, being discarded when a session ends.
+
 ## 2- Connection Authentication
 
 All connections require authentication, either via QR code or manually.
+
+As part of authentication, the receiver assigns a session ID and returns it to
+the sender. The session ID lets the receiver know that requests are authorized.
+A given session ID is tied to a particular transfer session. The session ID
+should be forgotten once the transfer concludes, whether it ends orderly or due
+to an error state.
+
+Requests for unknown or concluded transfer sessions should be rejected.
 
 ### 2.1- QR authentication (primary method)
 
 The host device displays a QR code containing:
 
 * Host's local IP address
-* Connection PIN
 * Port
 * Hash of the host's TLS certificate
+* Connection PIN
 
 QR payload:
 
@@ -73,8 +87,11 @@ When QR code scanning is not available, the host device will display:
 * 6 digit PIN
 * Port number 
 
+After entering the connection information, both the sender and the receiver will display a verification screen. 
 
-After entering the connection information, both the sender and the receiver will display a verification screen containing an alphanumeric sequence that encodes the hash of the receiver's TLS certificate.
+### 2.3- Verification screen
+
+Both the sender and the receiver will display a verification screen containing an alphanumeric sequence that encodes the hash of the receiver's TLS certificate.
 
 Both parties will verify that the same sequence is shown on each device before proceeding.
 
@@ -82,12 +99,14 @@ The verification screen will provide two options:
 * Confirm and Connect — Proceed with registration if the hashes match.
 * Discard and Start Over — Terminate the connection and the user should be returned to the main connection screen.
 
-
 Example of alphanumeric sequence (SHA-256 hash):
 
 ```markdown
 87fd 5869 a6b3 e414 112c 1934 ca00 be77 b8e4 584c 829a 4536 490b da9a 3928 be4a
 ```
+
+This same verification flow is re-used to confirm the sender certificate hash
+received in the register payload.
 
 **Security Note:** A hash mismatch indicates a potential machine-in-the-middle (MITM) attack.
 Users should verify that they are connecting to the intended device and ensure the network environment is secure before retrying.
@@ -110,31 +129,26 @@ Errors:
 
 For QR code authentication, registration is performed immediately after the QR code has been scanned.
 
-For manual authentication, registration is performed after the ping request and once the sender has verified the server certificate hash.
+For manual authentication, registration is performed after the ping request and once the sender has verified the receiver certificate hash.
 
-The register payload includes the sender's certificate hash. In this way the protocol
-establishes a mutual TLS (mTLS) connection: the receiver verifies the sender, and the sender
-verifies the receiver. Under mTLS the sender generates a TLS certificate and configures
-their TLS client to attach certificate information to each request.
+The sender should only generate one certificate and use that certificate for
+both setting the register payload's `senderCertificateHash` and for configuring
+the sender's TLS client.
 
-This further secures the connection by having the recipient "pin" the sender's certificate hash. 
+**Note**: Sender only needs to attach certificate information to requests that happen after registration.
 
-Pinning is done by checking the certificate information attached to each incoming request
-against the certificate hash saved from the register payload. If there is no certificate hash
-on a request or if there is a hash mismatch, the request is rejected. Certificate hashes are
-stored per session and discarded after a session ends.
-
-The sender's certificate hash is only saved after confirming that the register payload PIN
-as valid.
+If a request's connection has no certificate information or if the computed
+certificate hash does not match the pinned hash, the request should be rejected. 
 
 `POST /api/v1/register`
 
 Request payload
 
-```markdown {
+```markdown 
+{
+  senderCertificateHash: "sha256-hash-of-sender-TLS-certificate",
   pin: "123456",
   nonce: "random-uuid-number",
-  senderCertificateHash: "sha256-hash-of-sender-TLS-certificate"
 }
 ```
 
@@ -157,43 +171,66 @@ Errors:
 |401|Invalid PIN|
 |403|Rejected| 
 |409|Active session already exists|
-|413|Content too large|
 |429|Too many requests|
 |500|Server error|
 
 ### Flow
 
-Let’s consider Device A as the sender and Device B as the recipient.
-
 **QR Code Method:**
 
 - Device A (sender) scans the QR code containing:
     - Device B's IP address
-    - PIN
     - Port
-    - Certificate Hash
-- Device A (sender) sends the payload to `/api/v1/register`
+    - Receiver Certificate Hash
+    - PIN
+- Device A (sender) pins Receiver Certificate Hash
+- Device A (sender) sends the payload to `/api/v1/register`:
+    - Sender Certificate Hash
+    - PIN
+    - Nonce
+- Device A (sender) displays the Sender Certificate Hash to be compared 
 - Device B (recipient) receives the payload
+- Device B (recipient) displays the Sender Certificate Hash from register payload
+- Device B (recipient) checks PIN code is valid and pins Sender Certificate Hash from payload
 - Device B (recipient) returns the `sessionId`
 
-The recipient's Certificate Hash from the QR code is automatically compared with the hash received from the recipient.
+After Device A (sender) has pinned Receiver Certificate Hash from the QR code,
+Device A (sender) will independently compute each certificate hash on future responses
+sent from Device B (recipient). For each response sent by Device B (recipient),
+Device A (sender) hashes the certificate from the connection and checks the
+computed hash against the Receiver Certificate Hash pinned from the QR code.
+
+Device B (recipient) saves the Sender Certificate Hash after:
+
+1. Confirming the register payload PIN code is valid, and 
+2. Device B (receiver) has visually verified Device A (sender)'s certificate hash by comparing
+   the hash displayed on Device B (recipient) with the hash displayed on Device A (sender) (**2.3- Verification screen**).
+
+After Device B (recipient) has pinned Sender Certificate Hash from the register
+payload, Device B (recipient) will compute each certificate hash on future requests
+sent from Device A (sender). For each request sent after register, Device B
+(recipient) hashes the certificate from the connection and checks the computed
+hash against the Sender Certificate Hash pinned from the register payload.
 
 **Manual Method:**
 
 Initial Ping:
 - Device A (sender) manually types the IP address, PIN, and port
 - Device A (sender) sends a ping to `/api/v1/ping`
-- Device A (sender) retrieves the Certificate Hash from recipient 
-- Device A (sender) displays the Certificate Hash to be compared  
-- Device B (recipient) displays the Certificate Hash upon receiving the `/api/v1/ping` request     
+- Device A (sender) retrieves the Receiver Certificate Hash from recipient 
+- Device A (sender) displays the Receiver Certificate Hash to be compared  
+- Device B (recipient) displays the Receiver Certificate Hash upon receiving the `/api/v1/ping` request
     
 Initial Registration:
-- After confirming the Certificate Hash, Device A (sender) sends the payload to `/api/v1/register`
+- After confirming the Receiver Certificate Hash, Device A (sender) sends the payload to `/api/v1/register`
+    - Sender Certificate Hash
+    - PIN
+    - Nonce
+- Device A (sender) displays the Sender Certificate Hash to be compared 
 - Device B (recipient) receives the payload
-- Device B (recipient) pins the sender's Certificate Hash from the payload
-- Device B (recipient) confirms the registration request     
+- Device B (recipient) displays the Sender Certificate Hash from register payload
+- Device B (recipient) checks PIN code is valid and pins Sender Certificate Hash from payload
 - Device B (recipient) returns the `sessionId`
-
 
 ## 4- File Transfer
 
@@ -247,6 +284,7 @@ Errors:
 |400|Invalid request format|
 |401|Invalid session ID|
 |403|Rejected|
+|413|Content too large|
 |429|Too many requests|
 |500|Server error|
 
@@ -255,7 +293,6 @@ Errors:
 The file upload requires the sessionId, fileId, and its file-specific transmissionId obtained from /prepare-upload.
 
 `PUT /api/v1/upload?sessionId=sessionId&fileId=fileId&transmissionId=transmissionId&nonce=random-uuid-number`
-
 
 Request payload
 
@@ -287,7 +324,7 @@ Errors:
 
 **Note**: 
 1. After a successful upload, the transmissionId should be regarded as used. Any following requests for that transmissionId should return 403 "Invalid tranmission ID".
-2. `nonce` should be a unique nonce (UUID V4) for each upload request. See section **5.2 Replay Protection**.
+2. `nonce` should be a unique nonce (UUID V4) for each upload request and tied to each session. See section **5.2 Replay Protection**.
 
 ### 4.3 Close Connection
 
@@ -330,11 +367,25 @@ Errors:
 All routes are rate-limited per IP address, limiting the amount of requests a
 single IP is allowed to make for each route.
 
-If an IP address becomes rate-limited, its requests are ignored and the
-error 429 "Too many requests" sent as response.
+If an IP address becomes rate-limited, its request contents should be ignored
+and the error 429 "Too many requests" sent as response.
 
 ### 5.2 Replay Protection
 
-All routes that submit data are guarded against replay attacks by the inclusion
-of a nonce. If a request contains a nonce that has been seen, that request is
-regarded as invalid and is rejected.
+All routes that submit data during a session are guarded against replay attacks
+by the inclusion of a nonce. Nonces are associated with a particular transfer
+session. 
+
+A request whose `sessionID` does not match the session ID of an ongoing transfer
+session is an invalid request and should be rejected. A request containing a
+nonce that has already been handled in an ongoing transfer session is regarded
+as invalid and should be rejected.
+
+The above can be modeled as the following pseudocode:
+
+```
+// `seen` is a map operated by the receiver with string keys and boolean values
+if !sessionValid(request.sessionID) || seen[request.nonce] {
+    reject(request)
+}
+``` 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Nearby Sharing in Tella was designed for contexts of repression and surveillance
 * Certificates are verified to prevent machine-in-the-middle (MITM) attacks.
 * All connections use a specific port: 53317
 
-To minimize attack surfaces, TLS 1.3 is the only TLS version supported by the protocol.
+The TLS versions in use are TLS1.2 and TLS1.3. Implementations pick the highest version
+supported by both sender and receiver.
 
 ## 2- Connection Authentication
 
@@ -218,9 +219,6 @@ Response Payload
 **Note:** 
 
 1. `sha256` should be the SHA256 hash of the given file, encoded as a hexadecimal (base 16) string.
-2. The maximum allowed size of a single file is XXX (4-12?) GB (xxxxx bytes).
-3. The maximum allowed number of files that can be sent is XXX.
-4. The maximum allowed total upload size (the sum of all files sizes) is XXX (50-100?) GB (xxxxx bytes).
 
 Errors:
 

--- a/README.md
+++ b/README.md
@@ -32,13 +32,14 @@ Nearby Sharing in Tella was designed for contexts of repression and surveillance
 
 * All connections are secured with HTTPS using self-signed certificates generated per device.
 * Authentication is mandatory via PIN and IP address, provided through QR code scanning or manual entry.
-* Certificates are verified to prevent machine-in-the-middle (MITM) attacks
-* All connections use a specific port : 53317
+* Certificates are verified to prevent machine-in-the-middle (MITM) attacks.
+* All connections use a specific port: 53317
 
+To minimize attack surfaces, TLS 1.3 is the only TLS version supported by the protocol.
 
 ## 2- Connection Authentication
 
-All connections require authentication, either via QR code or manually
+All connections require authentication, either via QR code or manually.
 
 ### 2.1- QR authentication (primary method)
 
@@ -94,6 +95,12 @@ Users should verify that they are connecting to the intended device and ensure t
 `POST /api/v1/ping`
 
 This endpoint initiates a secure handshake between two devices during the manual connection process. It must be called before the register endpoint. Once called, both the sender and receiver display the verification screen.
+
+Errors:
+
+|HTTP code|Message|
+|--|--|
+|429|Too many requests|
 
 ### 3.2- Initial Registration
 
@@ -181,11 +188,13 @@ Request Payload
 {
   "title": "Title of the report",
   "sessionId": "uuid-session-identifier",
+  "nonce": "random-uuid-number"
   "files": [
     {
       "id": "file-uuid",
       "fileName": "document.pdf",
       "size": 324242,
+      "sha256": "57bb905d0f2ccecbb9d81d40daa17e1e05b109c833ddc766edb0b59561088f20",
       "fileType": "application/pdf",
       "thumbnail": "thumbnail-data"
     }
@@ -206,6 +215,13 @@ Response Payload
 }
 ```
 
+**Note:** 
+
+1. `sha256` should be the SHA256 hash of the given file, encoded as a hexadecimal (base 16) string.
+2. The maximum allowed size of a single file is XXX (4-12?) GB (xxxxx bytes).
+3. The maximum allowed number of files that can be sent is XXX.
+4. The maximum allowed total upload size (the sum of all files sizes) is XXX (50-100?) GB (xxxxx bytes).
+
 Errors:
 
 |HTTP code|Message|
@@ -213,13 +229,15 @@ Errors:
 |400|Invalid request format|
 |401|Invalid session ID|
 |403|Rejected|
+|413|Content too large|
+|429|Too many requests|
 |500|Server error|
 
 ### 4.2 File Upload
 
 The file upload requires the sessionId, fileId, and its file-specific transmissionId obtained from /prepare-upload.
 
-`PUT /api/v1/upload?sessionId=sessionId&fileId=fileId&transmissionId=transmissionId`
+`PUT /api/v1/upload?sessionId=sessionId&fileId=fileId&transmissionId=transmissionId&nonce=random-uuid-number`
 
 
 Request payload
@@ -245,7 +263,13 @@ Errors:
 |401|Invalid session ID|
 |403|Invalid transmission ID|
 |409|Transfer already completed|
+|413|Content too large|
+|429|Too many requests|
 |500|Server error|
+
+**Note**: 
+1. After a successful upload, the transmissionId should be regarded as used. Any following requests for that transmissionId should return 403 "Invalid tranmission ID".
+2. `nonce` should be a unique nonce (UUID V4) for each upload request. See section **5.2 Replay Protection**.
 
 ### 4.3 Close Connection
 
@@ -278,5 +302,21 @@ Errors:
 |400|Invalid request format|
 |401|Invalid session ID|
 |403|Session already closed|
+|429|Too many requests|
 |500|Server error|
 
+## 5. Rate-limiting and replay protection
+
+### 5.1 Rate-limiting
+
+All routes are rate-limited per IP address, limiting the amount of requests a
+single IP is allowed to make for each route.
+
+If an IP address becomes rate-limited, its requests are ignored and the
+error 429 "Too many requests" sent as response.
+
+### 5.2 Replay Protection
+
+All routes that submit data are guarded against replay attacks by the inclusion
+of a nonce. If a request contains a nonce that has been seen, that request is
+regarded as invalid and is rejected.

--- a/README.md
+++ b/README.md
@@ -246,7 +246,6 @@ Errors:
 |400|Invalid request format|
 |401|Invalid session ID|
 |403|Rejected|
-|413|Content too large|
 |429|Too many requests|
 |500|Server error|
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Errors:
 |401|Invalid PIN|
 |403|Rejected| 
 |409|Active session already exists|
+|413|Content too large|
 |429|Too many requests|
 |500|Server error|
 
@@ -282,6 +283,7 @@ Errors:
 |413|Content too large|
 |429|Too many requests|
 |500|Server error|
+|507|Insufficient storage space|
 
 **Note**: 
 1. After a successful upload, the transmissionId should be regarded as used. Any following requests for that transmissionId should return 403 "Invalid tranmission ID".

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Nearby Sharing in Tella was designed for contexts of repression and surveillance
 * All connections are secured with HTTPS using self-signed certificates generated per device.
 * Authentication is mandatory via PIN and IP address, provided through QR code scanning or manual entry.
 * Certificates are verified to prevent machine-in-the-middle (MITM) attacks.
-* All connections use a specific port: 53317
+* All connections use a specific port: 53320
 
 The TLS versions in use are TLS1.2 and TLS1.3. Implementations pick the highest version
 supported by both sender and receiver.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The host device displays a QR code containing:
 * Host's local IP address
 * Connection PIN
 * Port
-* Hash of the TLS certificate
+* Hash of the host's TLS certificate
 
 QR payload:
 
@@ -71,7 +71,7 @@ When QR code scanning is not available, the host device will display:
 * Port number 
 
 
-After entering the connection information, both the sender and the receiver will display a verification screen containing an alphanumeric sequence that encodes the hash of the TLS certificate.
+After entering the connection information, both the sender and the receiver will display a verification screen containing an alphanumeric sequence that encodes the hash of the receiver's TLS certificate.
 
 Both parties will verify that the same sequence is shown on each device before proceeding.
 
@@ -105,18 +105,33 @@ Errors:
 
 ### 3.2- Initial Registration
 
-For QR code authentication, it is performed immediately after the QR code has been scanned.
+For QR code authentication, registration is performed immediately after the QR code has been scanned.
 
-For manual authentication, it is performed after the ping request and once the sender has verified the certificate hash.
+For manual authentication, registration is performed after the ping request and once the sender has verified the server certificate hash.
+
+The register payload includes the sender's certificate hash. In this way the protocol
+establishes a mutual TLS (mTLS) connection: the receiver verifies the sender, and the sender
+verifies the receiver. Under mTLS the sender generates a TLS certificate and configures
+their TLS client to attach certificate information to each request.
+
+This further secures the connection by having the recipient "pin" the sender's certificate hash. 
+
+Pinning is done by checking the certificate information attached to each incoming request
+against the certificate hash saved from the register payload. If there is no certificate hash
+on a request or if there is a hash mismatch, the request is rejected. Certificate hashes are
+stored per session and discarded after a session ends.
+
+The sender's certificate hash is only saved after confirming that the register payload PIN
+as valid.
 
 `POST /api/v1/register`
 
 Request payload
 
-```markdown
-{
+```markdown {
   pin: "123456",
   nonce: "random-uuid-number",
+  senderCertificateHash: "sha256-hash-of-sender-TLS-certificate"
 }
 ```
 
@@ -157,7 +172,7 @@ Let’s consider Device A as the sender and Device B as the recipient.
 - Device B (recipient) receives the payload
 - Device B (recipient) returns the `sessionId`
 
-The Certificate Hash from the QR code is automatically compared with the hash received from the recipient.
+The recipient's Certificate Hash from the QR code is automatically compared with the hash received from the recipient.
 
 **Manual Method:**
 
@@ -171,6 +186,7 @@ Initial Ping:
 Initial Registration:
 - After confirming the Certificate Hash, Device A (sender) sends the payload to `/api/v1/register`
 - Device B (recipient) receives the payload
+- Device B (recipient) pins the sender's Certificate Hash from the payload
 - Device B (recipient) confirms the registration request     
 - Device B (recipient) returns the `sessionId`
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Response payload
 }
 ```
 
-**Note:** A maximum of 3 invalid requests are allowed
+**Note:** A maximum of 3 invalid requests are allowed.
 
 Errors:
 
@@ -136,7 +136,7 @@ Errors:
 
 ### Flow
 
-Let’s consider Device A as the sender and Device B as the recipient
+Let’s consider Device A as the sender and Device B as the recipient.
 
 **QR Code Method:**
 
@@ -171,7 +171,7 @@ Initial Registration:
 
 ### 4.1 Prepare Upload
 
-This request contains only metadata. The receiver decides whether to accept or reject the request
+This request contains only metadata. The receiver decides whether to accept or reject the request.
 
 `POST /api/v1/prepare-upload`
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Errors:
     - Receiver Certificate Hash
     - PIN
 - Device A (sender) pins Receiver Certificate Hash
-- Device A (sender) sends the payload to `/api/v1/register`:
+- Device A (sender) sends a payload to `/api/v1/register` containing:
     - Sender Certificate Hash
     - PIN
     - Nonce

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 
 
-Nearby Sharing lets you securely share files, fully offline, across platforms and devices, assuring secure, anonymous, encrypted file transferes.
+Nearby Sharing lets you securely share files, fully offline, across platforms and devices, assuring secure, anonymous, encrypted file transfers.
 
-This repository describes the peer-to-peer file sharing protocol implemented by all Tella apps. 
+This repository describes the peer-to-peer file sharing protocol implemented by all [Tella](https://tella-app.org/) apps. 
 
 
 ## Platform and availability
@@ -19,7 +19,7 @@ This protocol (and Nearby Sharing feature in Tella in general) is inspired by th
 
 
 ## Context of use and key features
-Nearby Sharing in Tella was designed for contexts of repression and surveilance, including for being able to share sensitive information before, during and after internet shutdowns. Here are some key details:
+Nearby Sharing in Tella was designed for contexts of repression and surveillance, including for being able to share sensitive information before, during and after internet shutdowns. Here are some key details:
 
 - Independent of internet: Transfers work with or without an internet connection, even on surveilled or insecure Wi-Fi networks, by establishing a direct connection between devices instead of routing through the internet.
 - Works with Personal Hotspots: even if you don't have data on your phone's plan, you can still create a Personal Hotspot, invite the other person to connect to it, and be able to use Nearby Sharing.
@@ -32,7 +32,7 @@ Nearby Sharing in Tella was designed for contexts of repression and surveilance,
 
 * All connections are secured with HTTPS using self-signed certificates generated per device.
 * Authentication is mandatory via PIN and IP address, provided through QR code scanning or manual entry.
-* Certificates are verified to prevent man-in-the-middle (MITM) attacks
+* Certificates are verified to prevent machine-in-the-middle (MITM) attacks
 * All connections use a specific port : 53317
 
 
@@ -47,7 +47,7 @@ The host device displays a QR code containing:
 * Host's local IP address
 * Connection PIN
 * Port
-* Hash of the tls certificate
+* Hash of the TLS certificate
 
 QR payload:
 
@@ -84,7 +84,7 @@ Example of alphanumeric sequence (SHA-256 hash):
 87fd 5869 a6b3 e414 112c 1934 ca00 be77 b8e4 584c 829a 4536 490b da9a 3928 be4a
 ```
 
-**Security Note:** A hash mismatch indicates a potential man-in-the-middle (MITM) attack.
+**Security Note:** A hash mismatch indicates a potential machine-in-the-middle (MITM) attack.
 Users should verify that they are connecting to the intended device and ensure the network environment is secure before retrying.
 
 ## 3- Connection Establishment

--- a/README.md
+++ b/README.md
@@ -38,11 +38,9 @@ Nearby Sharing in Tella was designed for contexts of repression and surveillance
 The TLS versions in use are TLS1.2 and TLS1.3. Implementations pick the highest version
 supported by both sender and receiver.
 
-TLS certificates are generated and used on both sides of the connection to
-establish a mutual TLS (mTLS) connection: the sender verifies the receiver, and
-the receiver verifies the sender. 
+The receiver generates a self-signed TLS certificate which is used to secure all uploaded files. The sender verifies and pins a hash of the receiver's certificate before any uploads happen. 
 
-Certificate are generated and used per session, being discarded when a session ends.
+Certificates are generated and used per session, being discarded when a session ends.
 
 ## 2- Connection Authentication
 
@@ -105,9 +103,6 @@ Example of alphanumeric sequence (SHA-256 hash):
 87fd 5869 a6b3 e414 112c 1934 ca00 be77 b8e4 584c 829a 4536 490b da9a 3928 be4a
 ```
 
-This same verification flow is re-used to confirm the sender certificate hash
-received in the register payload.
-
 **Security Note:** A hash mismatch indicates a potential machine-in-the-middle (MITM) attack.
 Users should verify that they are connecting to the intended device and ensure the network environment is secure before retrying.
 
@@ -131,12 +126,6 @@ For QR code authentication, registration is performed immediately after the QR c
 
 For manual authentication, registration is performed after the ping request and once the sender has verified the receiver certificate hash.
 
-The sender should only generate one certificate and use that certificate for
-both setting the register payload's `senderCertificateHash` and for configuring
-the sender's TLS client.
-
-**Note**: Sender only needs to attach certificate information to requests that happen after registration.
-
 If a request's connection has no certificate information or if the computed
 certificate hash does not match the pinned hash, the request should be rejected. 
 
@@ -146,7 +135,6 @@ Request payload
 
 ```markdown 
 {
-  senderCertificateHash: "sha256-hash-of-sender-TLS-certificate",
   pin: "123456",
   nonce: "random-uuid-number",
 }
@@ -185,13 +173,10 @@ Errors:
     - PIN
 - Device A (sender) pins Receiver Certificate Hash
 - Device A (sender) sends a payload to `/api/v1/register` containing:
-    - Sender Certificate Hash
     - PIN
     - Nonce
-- Device A (sender) displays the Sender Certificate Hash to be compared 
 - Device B (recipient) receives the payload
-- Device B (recipient) displays the Sender Certificate Hash from register payload
-- Device B (recipient) checks PIN code is valid and pins Sender Certificate Hash from payload
+- Device B (recipient) checks PIN code is valid 
 - Device B (recipient) returns the `sessionId`
 
 After Device A (sender) has pinned Receiver Certificate Hash from the QR code,
@@ -199,18 +184,6 @@ Device A (sender) will independently compute each certificate hash on future res
 sent from Device B (recipient). For each response sent by Device B (recipient),
 Device A (sender) hashes the certificate from the connection and checks the
 computed hash against the Receiver Certificate Hash pinned from the QR code.
-
-Device B (recipient) saves the Sender Certificate Hash after:
-
-1. Confirming the register payload PIN code is valid, and 
-2. Device B (receiver) has visually verified Device A (sender)'s certificate hash by comparing
-   the hash displayed on Device B (recipient) with the hash displayed on Device A (sender) (**2.3- Verification screen**).
-
-After Device B (recipient) has pinned Sender Certificate Hash from the register
-payload, Device B (recipient) will compute each certificate hash on future requests
-sent from Device A (sender). For each request sent after register, Device B
-(recipient) hashes the certificate from the connection and checks the computed
-hash against the Sender Certificate Hash pinned from the register payload.
 
 **Manual Method:**
 
@@ -223,13 +196,10 @@ Initial Ping:
     
 Initial Registration:
 - After confirming the Receiver Certificate Hash, Device A (sender) sends the payload to `/api/v1/register`
-    - Sender Certificate Hash
     - PIN
     - Nonce
-- Device A (sender) displays the Sender Certificate Hash to be compared 
 - Device B (recipient) receives the payload
-- Device B (recipient) displays the Sender Certificate Hash from register payload
-- Device B (recipient) checks PIN code is valid and pins Sender Certificate Hash from payload
+- Device B (recipient) checks PIN code is valid
 - Device B (recipient) returns the `sessionId`
 
 ## 4- File Transfer


### PR DESCRIPTION
In this PR I have include changes intended to address findings of the security audit done in late 2025. 

This PR is created so that we can discuss what protocol changes can be made in the short-term based on team workloads and on the security benefit of the given change. Some things we might have to strike from the PR because of workloads or discussions, but hopefully we have the space to make changes that further improve Nearby Sharing's security profile.

The PR is a work in progress, some things (like exact values for max file sizes) are undecided at the time of submission. We should agree on limits all together, as they have an impact on usability (smaller sizes limits the files that can be sent) but also on security (limits effect of attacks, enables server-side size validation).

Having the PR discussion history lets us also have a good way to find out "wait why did we decide on this again?"

cc @carohadad @dhekra-rouatbi @ahlem-jarrar 

    Added in this commit:
    
    * TLS 1.3 requirement
    * A section about rate-limiting and replay protection
    * Nonces for each request that submits data
    * sha256 file hashes in prepare-upload
    * A note about limiting transmissionId reuse
    * 429 errors to all routes for rate-limiting
    * Explicit max sizes for prepare-upload (max file size, max number of
      files, max total size)

p.s. I also fixed up some punctuation and typos, and added a link to Tella's website.