### PR TITLE
Update protocol docs with mTLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,7 @@ code that may be sent back as a response from receivers running a newer incompat
 version:
 
 |HTTP code|Message|
+|--|--|
 |406|Unsupported version|
 
 As documented above in the protocol, this error code may be sent on the following routes:

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ information.  This creates the following four scenarios:
 
 **A: Receiver can scan / Sender can scan (100% QR flow)**
 
-1. Receiver scans Sender QR Code (no requests have been sent). Receiver pins Sender Certificate Hash.
+1. Receiver scans Sender QR code (no requests have been sent). Receiver pins Sender Certificate Hash.
 2. Sender scans Receiver QR code (still no requests have been sent). Sender pins Receiver Certificate Hash.
    * mTLS is now established
 3. Sender sends `POST /api/v2/register` (this is request 1)
@@ -302,7 +302,7 @@ information.  This creates the following four scenarios:
 
 **C: Receiver can scan / Sender cannot scan flow (Receiver Hash Verification)**
 
-1. Receiver scans Sender QR Code (no requests have been sent). Receiver pins Sender Certificate Hash.
+1. Receiver scans Sender QR code (no requests have been sent). Receiver pins Sender Certificate Hash.
 2. Sender does manual connection, types in Receiver IP Address, PIN, Port. Sender sends `POST /api/v2/ping` (this is request 1)
 3. Receiver sends back ping response. 
 4. Sender extracts Receiver Certificate Hash from ping response.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The receiver device displays a QR code containing:
 * Hash of the receiver's TLS certificate
 * Connection PIN
 * Protocol version number
+* Whether sender in step 2 of section *New flow* should directly show hash verification
 
 QR payload:
 
@@ -77,9 +78,14 @@ QR payload:
   port: Number,
   certificate_hash: String,
   pin: String,
-  protocol_version: Number
+  protocol_version: Number,
+  sender_show_hash: Booolean
 }
 ```
+
+If for example the receiver is a desktop client, `sender_show_hash` should be set to `true` and
+sender in step 2 in section *New flow* should skip display of the QR code and directly show the
+hash verification screen.
 
 For the protocol described in the current document, the protocol version should be set to
 `protocol_version: 2`
@@ -157,9 +163,9 @@ The sender should only generate one certificate and use that certificate for con
 
 **Note**: Sender needs to attach its certificate information to the registration request and then to all subsequent requests.
 
-After successful registration, mTLS has been established. This means that requests and
+After successful registration, mTLS has been established. After registration, requests and
 responses that do not have attached certificate information should be automatically rejected.
-If a computed certificate hash does not match the pinned hash, the coresponding request or
+Also if a computed certificate hash does not match the pinned hash, the corresponding request or
 response should also be rejected.
 
 `POST /api/v2/register`

--- a/README.md
+++ b/README.md
@@ -278,8 +278,7 @@ When Device B (receiver) cannot scan Sender QR code (broken screen/camera or com
 * Device A (sender) sends register request payload outlined in *3.2- Initial Registration*.
 * Device A (sender) displays the hash of their TLS certificate.
 * Device B (receiver) processes registration request, making sure that PIN is correct and nonce has not.
-  been seen (**Note:** this must happen before extracting certificate information in next
-  step).
+  been seen (**Note:** Sender Certificate Hash must not be displayed before having verified the PIN is correct & nonce unseen).
 * Device B (receiver) extracts the sender's certificate information from the connection info of the registration request, hashes it, and displays the Sender Certificate Hash.
 * Device A (sender) and Device B (receiver) visually compare the hashes as outlined in *2.3- Verification screen*.
 * If verification succeds, Device B (receiver) pins the Sender Certificate Hash.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,9 @@ ping response payload.
 
 For QR code authentication, registration is performed immediately after the QR code has been scanned.
 
-For manual authentication, registration is performed after the ping request and once the sender has verified the receiver certificate hash.
+For manual authentication, registration is performed after the ping request and once the sender
+has verified the Receiver Certificate Hash. The receiver sends its ping response after
+verification of the Receiver Certificate Hash.
 
 The sender should only generate one certificate and use that certificate for configuring the sender's TLS client.
 
@@ -327,27 +329,27 @@ the other device.
 
 1. Receiver scans Sender QR code (no requests have been sent). Receiver pins Sender Certificate Hash.
 2. Sender does manual connection, types in Receiver IP Address, PIN, Port. Sender sends `POST /api/v2/ping` (this is request 1).
-3. Receiver sends back ping response. 
-4. Sender extracts Receiver Certificate Hash from ping response.
-5. Receiver Hash Verification commences.
-6. Both parties confirm Receiver Hash and continue. Sender pins Receiver Certificate Hash.
+3. Sender extracts Receiver Certificate Hash from ping response.
+4. Receiver Hash Verification commences.
+5. Both parties confirm Receiver Hash and continue. Sender pins Receiver Certificate Hash.
    *  mTLS is now established.
+6. Receiver sends back ping response. 
 7. Sender sends `POST /api/v2/register` (this is request 2).
 
 **D: Receiver cannot scan / Sender cannot scan (Receiver Hash Verification and Sender Hash Verification; 0% QR codes)**
 
 1. Receiver marks that they can't scan QR codes.
 2. Sender does manual connection, types in Receiver IP Address, PIN, Port. Sender sends `POST /api/v2/ping` (this is request 1).
-3. Receiver sends back ping response. 
-4. Sender extracts Receiver Certificate Hash from response.
-5. Receiver Hash Verification commences.
-6. Both parties confirm Receiver Hash and continue. Sender pins Receiver Certificate Hash.
-8. Sender sends `POST /api/v2/register` (this is request 2).
-9. Receiver confirms PIN correct and nonce unseen. Receiver extracts Sender Certificate Hash from register request.
-10. Sender Hash Verification commences.
-11. Both parties confirm Sender Hash and continue. Receiver pins Sender Certificate Hash.
+3. Sender extracts Receiver Certificate Hash from response.
+4. Receiver Hash Verification commences.
+5. Both parties confirm Receiver Hash and continue. Sender pins Receiver Certificate Hash.
+6. Receiver sends back ping response. 
+7. Sender sends `POST /api/v2/register` (this is request 2).
+8. Receiver confirms PIN correct and nonce unseen. Receiver extracts Sender Certificate Hash from register request.
+9. Sender Hash Verification commences.
+10. Both parties confirm Sender Hash and continue. Receiver pins Sender Certificate Hash.
 	* mTLS is now established.
-12. Receiver sends register response back to sender.
+11. Receiver sends register response back to sender.
 
 ## 4- File Transfer
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The receiver device displays a QR code containing:
 
 * Receiver's local IP address
 * Port
-* Hash of the receiver's TLS certificate
+* Receiver Certificate Hash
 * Connection PIN
 * Protocol version number
 * Whether sender in step 2 of section *New flow* should directly show hash verification
@@ -102,7 +102,7 @@ addresses.
 
 The sender device displays a QR code containing:
 
-* Hash of the sender's TLS certificate
+* Sender Certificate Hash
 
 QR payload:
 
@@ -225,7 +225,7 @@ Errors:
 
 For this flow we use the notation Device A (sender) and Device B (receiver).
 
-**Step 1: Pin receiver certificate**
+**Step 1: Pin Receiver Certificate Hash**
 
 When sender can scan Receiver QR code: 
 
@@ -250,7 +250,7 @@ received after pinning, Device A (sender) hashes the certificate information
 from the connection and checks the computed hash against the pinned Receiver
 Certificate Hash.
 
-**Step 2: Pin sender certificate**
+**Step 2: Pin Sender Certificate Hash**
 
 When receiver can scan Sender QR code: 
 

--- a/README.md
+++ b/README.md
@@ -147,11 +147,6 @@ Users should verify that they are connecting to the intended device and ensure t
 
 This endpoint initiates a secure handshake between two devices during the manual connection process. It must be called before the register endpoint. Once called, both the sender and receiver display the verification screen.
 
-**Security note**: Sender should only save the data (senderShowHash) from the
-ping response after Receiver Hash Verification has been completed. Only after
-verifying the Receiver Certificate Hash does sender know they can trust the
-ping response payload.
-
 Response payload
 
 ```markdown
@@ -166,6 +161,11 @@ Errors:
 |--|--|
 |429|Too many requests|
 |406|Unsupported version|
+
+**Security note**: Sender should only save the data (senderShowHash) from the
+ping response after Receiver Hash Verification has been completed. Only after
+verifying the Receiver Certificate Hash does sender know they can trust the
+ping response payload.
 
 ### 3.2- Initial Registration
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tella Nearby Sharing Protocol
 
-
+Protocol version: 2
 
 Nearby Sharing lets you securely share files, fully offline, across platforms and devices, assuring secure, anonymous, encrypted file transfers.
 
@@ -453,3 +453,50 @@ if !sessionValid(request.sessionID) || seen[request.nonce] {
     reject(request)
 }
 ``` 
+
+## 6. Version negotation
+
+Offline peer-to-peer protocols provide unique opportunities for enabling long-lasting
+application lifetimes. This presents a difficult in terms of navigating incompatible versions. 
+
+Protocol version 2 is wholly incompatible with version 1 due to the introduction of compulsory mTLS.
+
+### Handling version 1 and version 2 incompatibility
+
+When a receiver or a sender on version 2 detects an incompatibility, they should display the
+Incompatible Versions Message describing that the two clients can't proceed because the other
+client is running an older, incompatible version.
+
+Version 1 and version 2 incompatibility can be detected in the following situations and should be
+reacted to as described:
+
+1. When a version 2 sender scans a version 1 Receiver QR Code, the sender can detect the situation by
+  the lack of `protocol_version` in the Receiver QR Code. As a result, the sender should not
+  send a register request to the receiver. It should instead display the Incompatible Versions
+  Message on the sender's screen with information saying that the receiver is running an
+  older, incompatible version.
+1. A version 2 receiver that receives any requests with the route prefix `/api/v1/` should, if
+   possible, respond with a suitable error code that is known to be implemented by the version
+   1 sender. In particular:
+  1. Requests for `/api/v1/register` should return `403 Rejected` to the version 1 sender. The
+    version 2 receiver should display the Incompatible Versions Message on its screen, saying
+    that the sender was running the older version. This occurs when a version 1 sender scans a
+    version 2 Receiver QR Code.
+  1. Requests for `/api/v1/ping` should be ignored (error code 429 is not suitable). When
+     receiving version 1 ping requests and a mTLS connection has not yet been established, the
+     version 2 receiver should display the Incompatible Versions Message.
+1. A version 2 sender that sends a request to a version 1 sender will send requests to routes
+   with the prefix `/api/v2`. Requests to these routes may not receive any response. This
+   occurs when a version 2 sender tries to manually connect to a version 1 receiver i.e. it
+   concerns the *Initial Ping* used by the manual connection process.
+      * TODO: should the handling behaviour be to have a timeout before displaying "no
+        response; maybe incompatible version?" how do android/ios handle this in v1?
+
+### How version 2 and future versions handle incompatibilities
+
+When a sender scans a Receiver QR code and the value of field `protocol_version` is an
+unsupported version the sender should display the Incompatible Versions Message.
+
+TODO: if we describe how to handle requests for unhandled routes that could allow attacks to
+discover what protocol version (and implicit a range of versions of Tella that may be running)
+a particular receiver is running.

--- a/README.md
+++ b/README.md
@@ -154,9 +154,10 @@ The sender should only generate one certificate and use that certificate for con
 
 **Note**: Sender needs to attach its certificate information to the registration request and then to all subsequent requests.
 
-If a request's connection has no certificate information or if a computed certificate hash
-does not match the pinned hash, the request should be rejected. The same applies to the
-receiver's responses.
+After successful registration, mTLS has been established. This means that requests and
+responses that do not have attached certificate information should be automatically rejected.
+If a computed certificate hash does not match the pinned hash, the coresponding request or
+response should also be rejected.
 
 `POST /api/v2/register`
 

--- a/README.md
+++ b/README.md
@@ -38,10 +38,13 @@ Nearby Sharing in Tella was designed for contexts of repression and surveillance
 The TLS versions in use are TLS1.2 and TLS1.3. Implementations pick the highest version
 supported by both sender and receiver.
 
-
 Self-signed TLS certificates are generated and used on both sides of the connection to
 establish a mutual TLS (mTLS) connection: the sender verifies the receiver, and
 the receiver verifies the sender.
+
+In this document we call the fingerprint identifying the sender's certificate as the Sender
+Certificate Hash. In the same way the receiver's certificate is identified by the Receiver
+Certificate Hash.
 
 Certificates are generated and used per session, being discarded when a session ends.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ Nearby Sharing in Tella was designed for contexts of repression and surveillance
 The TLS versions in use are TLS1.2 and TLS1.3. Implementations pick the highest version
 supported by both sender and receiver.
 
-The receiver generates a self-signed TLS certificate which is used to secure all uploaded files. The sender verifies and pins a hash of the receiver's certificate before any uploads happen. 
+
+Self-signed TLS certificates are generated and used on both sides of the connection to
+establish a mutual TLS (mTLS) connection: the sender verifies the receiver, and
+the receiver verifies the sender.
 
 Certificates are generated and used per session, being discarded when a session ends.
 
@@ -56,12 +59,15 @@ Requests for unknown or concluded transfer sessions should be rejected.
 
 ### 2.1- QR authentication (primary method)
 
-The host device displays a QR code containing:
+#### 2.1.1 Receiver QR code
 
-* Host's local IP address
+The receiver device displays a QR code containing:
+
+* Receiver's local IP address
 * Port
-* Hash of the host's TLS certificate
+* Hash of the receiver's TLS certificate
 * Connection PIN
+* Protocol version number
 
 QR payload:
 
@@ -70,16 +76,31 @@ QR payload:
   ip_address: [String, ..., ..., String],
   port: Number,
   certificate_hash: String,
-  pin: String
+  pin: String,
+  protocol_version: Number
 }
 ```
 
 **Note:** `ip_address` is a list of strings, as the receiver may have many different local IP
 addresses.
 
+#### 2.1.2 Sender QR code
+
+The sender device displays a QR code containing:
+
+* Hash of the sender's TLS certificate
+
+QR payload:
+
+```json5
+{
+  certificate_hash: String
+}
+```
+
 ### 2.2- Manual authentication (Fallback Method)
 
-When QR code scanning is not available, the host device will display:
+When QR code scanning is not available, the receiver device will display:
 
 * IP address
 * 6 digit PIN
@@ -100,7 +121,10 @@ The verification screen will provide two options:
 Example of alphanumeric sequence (SHA-256 hash):
 
 ```markdown
-87fd 5869 a6b3 e414 112c 1934 ca00 be77 b8e4 584c 829a 4536 490b da9a 3928 be4a
+87fd 5869 a6b3 e414 
+112c 1934 ca00 be77 
+b8e4 584c 829a 4536 
+490b da9a 3928 be4a
 ```
 
 **Security Note:** A hash mismatch indicates a potential machine-in-the-middle (MITM) attack.
@@ -110,7 +134,7 @@ Users should verify that they are connecting to the intended device and ensure t
 
 ### 3.1 Initial Ping
 
-`POST /api/v1/ping`
+`POST /api/v2/ping`
 
 This endpoint initiates a secure handshake between two devices during the manual connection process. It must be called before the register endpoint. Once called, both the sender and receiver display the verification screen.
 
@@ -126,10 +150,15 @@ For QR code authentication, registration is performed immediately after the QR c
 
 For manual authentication, registration is performed after the ping request and once the sender has verified the receiver certificate hash.
 
-If a request's connection has no certificate information or if the computed
-certificate hash does not match the pinned hash, the request should be rejected. 
+The sender should only generate one certificate and use that certificate for configuring the sender's TLS client.
 
-`POST /api/v1/register`
+**Note**: Sender needs to attach its certificate information to the registration request and then to all subsequent requests.
+
+If a request's connection has no certificate information or if a computed certificate hash
+does not match the pinned hash, the request should be rejected. The same applies to the
+receiver's responses.
+
+`POST /api/v2/register`
 
 Request payload
 
@@ -162,7 +191,62 @@ Errors:
 |429|Too many requests|
 |500|Server error|
 
-### Flow
+#### New flow
+
+For this flow we use the notation Device A (sender) and Device B (receiver).
+
+**Step 1: Pin receiver certificate**
+
+When sender can scan QR codes: 
+
+* Device B (receiver) presents QR code containing information outlined in *2.1.1 Receiver QR code*
+* Device A (sender) scans QR code, parses information, and pins the embedded Receiver Certificate Hash
+
+When sender cannot scan QR codes (broken screen/camera or comms with desktop):
+
+* Device B (receiver) displays manual connection info outlined in *2.2- Manual authentication (Fallback Method)*
+* Device A (sender) types in manual connection info and sends ping request outlined in *3.1 Initial Ping*
+* Device B (receiver) sends response to ping request
+* Device B (receiver) displays the hash of their TLS certificate
+* Device A (sender) extracts the receiver's certificate information from the connection info for the ping
+  response, hashes it, and displays the Receiver Certificate Hash
+* Device A (sender) and receiver visually compare the hashes as outlined in *2.3- Verification screen*
+* If verification succeds, the sender pins the Receiver Certificate Hash
+* Proceed to step 2
+
+After Device A (sender) has pinned Receiver Certificate Hash, Device A (sender)
+will compute each certificate hash on all future responses. For each response
+received after pinning, Device A (sender) hashes the certificate information
+from the connection and checks the computed hash against the pinned Receiver
+Certificate Hash.
+
+**Step 2: Pin sender certificate**
+
+When receiver can scan QR codes: 
+
+* Device A (sender) presents QR code containing the sender's certificate hash outlined in *2.1.2 Sender QR code*
+* Device B (receiver) scans QR code, parses information, and pins the embedded Sender Certificate Hash
+* Device A (sender) sends register request payload outlined in *3.2- Initial Registration*
+* Device B (receiver) processes registration request, making sure that PIN is correct and nonce has not been seen
+* Finalise registration. Mutual TLS has been established, proceed to *4.1 Prepare upload*
+
+When receiver cannot scan QR codes (broken screen/camera or comms with desktop):
+
+* Device A (sender) sends register request payload outlined in *3.2- Initial Registration*
+* Device A (sender) displays the hash of their TLS certificate
+* Device B (receiver) processes registration request, making sure that PIN is correct and nonce has not
+  been seen (**Note:** this must happen before extracting certificate information in next step)
+* Device B (receiver) extracts the sender's certificate information from the connection info of the registration request, hashes it, and displays the Sender Certificate Hash
+* Device A (sender) and receiver visually compare the hashes as outlined in *2.3- Verification screen*
+* If verification succeds, the receiver pins the Sender Certificate Hash
+* Finalise registration. Mutual TLS has been established, proceed to *4.1 Prepare upload*
+
+After Device B (receiver) has pinned the Sender Certificate Hash, Device B
+(receiver) will compute each certificate hash on all future requests. For each
+request sent after register, Device B (receiver) hashes the certificate information from
+the connection and checks the computed hash against the pinned Sender Certificate Hash.
+
+### Old Flow (section to be removed after new flow is finalised)
 
 **QR Code Method:**
 
@@ -172,7 +256,7 @@ Errors:
     - Receiver Certificate Hash
     - PIN
 - Device A (sender) pins Receiver Certificate Hash
-- Device A (sender) sends a payload to `/api/v1/register` containing:
+- Device A (sender) sends a payload to `/api/v2/register` containing:
     - PIN
     - Nonce
 - Device B (recipient) receives the payload
@@ -189,13 +273,13 @@ computed hash against the Receiver Certificate Hash pinned from the QR code.
 
 Initial Ping:
 - Device A (sender) manually types the IP address, PIN, and port
-- Device A (sender) sends a ping to `/api/v1/ping`
+- Device A (sender) sends a ping to `/api/v2/ping`
 - Device A (sender) retrieves the Receiver Certificate Hash from recipient 
 - Device A (sender) displays the Receiver Certificate Hash to be compared  
-- Device B (recipient) displays the Receiver Certificate Hash upon receiving the `/api/v1/ping` request
+- Device B (recipient) displays the Receiver Certificate Hash upon receiving the `/api/v2/ping` request
     
 Initial Registration:
-- After confirming the Receiver Certificate Hash, Device A (sender) sends the payload to `/api/v1/register`
+- After confirming the Receiver Certificate Hash, Device A (sender) sends the payload to `/api/v2/register`
     - PIN
     - Nonce
 - Device B (recipient) receives the payload
@@ -208,7 +292,7 @@ Initial Registration:
 
 This request contains only metadata. The receiver decides whether to accept or reject the request.
 
-`POST /api/v1/prepare-upload`
+`POST /api/v2/prepare-upload`
 
 Request Payload
 
@@ -262,7 +346,7 @@ Errors:
 
 The file upload requires the sessionId, fileId, and its file-specific transmissionId obtained from /prepare-upload.
 
-`PUT /api/v1/upload?sessionId=sessionId&fileId=fileId&transmissionId=transmissionId&nonce=random-uuid-number`
+`PUT /api/v2/upload?sessionId=sessionId&fileId=fileId&transmissionId=transmissionId&nonce=random-uuid-number`
 
 Request payload
 
@@ -302,7 +386,7 @@ This request is sent by the sender to terminate the session.
 
 The `sessionId` is obtained from /prepare-upload.
 
-`POST /api/v1/close-connection`
+`POST /api/v2/close-connection`
 
 Request Payload
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ establish a mutual TLS (mTLS) connection: the sender verifies the receiver, and
 the receiver verifies the sender.
 
 Certificate verification is done by comparing certificate fingerprints on both sides of the
-connection. The fingerprints are derived by SHA256-hashing certificate information and
-representing the resulting hash as a hexadecimal string. Accordingly in this document we call
-the fingerprint identifying the sender's certificate the Sender Certificate Hash. In the
-same way the receiver's certificate is identified by the Receiver Certificate Hash.
+connection. The fingerprints are derived by SHA256-hashing the raw bytes of the certificate
+attached to a request/response and representing the resulting hash as a hexadecimal string.
+Accordingly in this document we call the fingerprint identifying the sender's certificate the
+Sender Certificate Hash. In the same way the receiver's certificate is identified by the
+Receiver Certificate Hash.
 
 Certificates are generated and used per session, being discarded when a session ends.
 
@@ -228,7 +229,7 @@ Errors:
 
 The security of mTLS amounts to each side of a connection being secured by a TLS certificate
 belonging to an authorized party. Since this protocol relies on the use of self-signed
-certificates, the certificates have to be verified. In this protocol, verification is done
+certificates, the certificates have to be verified. Verification is done
 either automatically (out-of-band QR code transmission of certificate fingerprint) or through
 manual visual inspection of a certificate fingerprint. Once a certificate has been verified,
 the fingerprint is saved and used to compare against future traffic, verifying the traffic

--- a/README.md
+++ b/README.md
@@ -147,11 +147,25 @@ Users should verify that they are connecting to the intended device and ensure t
 
 This endpoint initiates a secure handshake between two devices during the manual connection process. It must be called before the register endpoint. Once called, both the sender and receiver display the verification screen.
 
+**Security note**: Sender should only save the data (senderShowHash) from the
+ping response after Receiver Hash Verification has been completed. Only after
+verifying the Receiver Certificate Hash does sender know they can trust the
+ping response payload.
+
+Response payload
+
+```markdown
+{
+  "senderShowHash": boolean
+}
+```
+
 Errors:
 
 |HTTP code|Message|
 |--|--|
 |429|Too many requests|
+|406|Unsupported version|
 
 ### 3.2- Initial Registration
 
@@ -197,6 +211,7 @@ Errors:
 |400|Invalid request format|
 |401|Invalid PIN|
 |403|Rejected| 
+|406|Unsupported version|
 |409|Active session already exists|
 |429|Too many requests|
 |500|Server error|
@@ -207,12 +222,12 @@ For this flow we use the notation Device A (sender) and Device B (receiver).
 
 **Step 1: Pin receiver certificate**
 
-When sender can scan QR codes: 
+When sender can scan receiver QR codes: 
 
 * Device B (receiver) presents QR code containing information outlined in *2.1.1 Receiver QR code*
 * Device A (sender) scans QR code, parses information, and pins the embedded Receiver Certificate Hash
 
-When sender cannot scan QR codes (broken screen/camera or comms with desktop):
+When sender cannot scan receiver QR codes (broken screen/camera or comms with desktop):
 
 * Device B (receiver) displays manual connection info outlined in *2.2- Manual authentication (Fallback Method)*
 * Device A (sender) types in manual connection info and sends ping request outlined in *3.1 Initial Ping*
@@ -232,7 +247,7 @@ Certificate Hash.
 
 **Step 2: Pin sender certificate**
 
-When receiver can scan QR codes: 
+When receiver can scan sender QR codes: 
 
 * Device A (sender) presents QR code containing the sender's certificate hash outlined in *2.1.2 Sender QR code*
 * Device B (receiver) scans QR code, parses information, and pins the embedded Sender Certificate Hash
@@ -240,7 +255,7 @@ When receiver can scan QR codes:
 * Device B (receiver) processes registration request, making sure that PIN is correct and nonce has not been seen
 * Finalise registration. Mutual TLS has been established, proceed to *4.1 Prepare upload*
 
-When receiver cannot scan QR codes (broken screen/camera or comms with desktop):
+When receiver cannot scan sender QR codes (broken screen/camera or comms with desktop):
 
 * Device A (sender) sends register request payload outlined in *3.2- Initial Registration*
 * Device A (sender) displays the hash of their TLS certificate
@@ -255,6 +270,61 @@ After Device B (receiver) has pinned the Sender Certificate Hash, Device B
 (receiver) will compute each certificate hash on all future requests. For each
 request sent after register, Device B (receiver) hashes the certificate information from
 the connection and checks the computed hash against the pinned Sender Certificate Hash.
+
+##### Connection scenarios
+
+Connection establishment and exchange of certification information can be done
+through a mix of QR code scanning and manual verification of connection
+information.  This creates the following four scenarios:
+
+A. 100% QR flow
+B. Receiver displays QR code + Sender Hash Verification
+C. Sender displays QR code + Receiver Hash Verification 
+D. Receiver Hash Verification + Sender Hash Verification (0% QR codes)
+
+**A: Receiver can scan / Sender can scan (100% QR flow)**
+
+1. Receiver scans Sender QR Code (no requests have been sent). Receiver pins Sender Certificate Hash.
+2. Sender scans Receiver QR Code (still no requests have been sent). Sender pins Receiver Certificate Hash.
+   * mTLS is now established
+3. Sender sends `POST /api/v2/register` (this is request 1)
+
+**B: Receiver cannot scan / Sender can scan flow (Sender Hash Verification)**
+
+1. Receiver marks that they can't scan QR codes
+2. Sender scans Receiver QR Code (no requests have been sent). Sender pins Receiver Certificate Hash.
+3. Sender sends `POST /api/v2/register` (this is request 1)
+4. Receiver confirms PIN correct and nonce unseen. Receiver extracts Sender Certificate Hash from register request.
+5. Sender Hash Verification commences
+6. Both parties confirm Sender Hash and continue. Receiver pins Sender Certificate Hash.
+   * mTLS is now established
+7. Receiver sends register response back to sender
+
+**C: Receiver can scan / Sender cannot scan flow (Receiver Hash Verification)**
+
+1. Receiver scans Sender QR Code (no requests have been sent). Receiver pins Sender Certificate Hash.
+2. Sender does manual connection, types in Receiver IP Address, PIN, Port. Sender sends `POST /api/v2/ping` (this is request 1)
+3. Receiver sends back ping response. 
+4. Sender extracts Receiver Certificate Hash from ping response.
+5. Receiver Hash Verification commences
+6. Both parties confirm Receiver Hash and continue. Sender pins Receiver Certificate Hash.
+   *  mTLS is now established
+7. Sender sends `POST /api/v2/register` (this is request 2)
+
+**D: Receiver cannot scan / Sender cannot scan flow (Receiver Hash Verification and Sender Hash Verification)**:
+
+1. Receiver marks that they can't scan QR codes
+2. Sender does manual connection, types in Receiver IP Address, PIN, Port. Sender sends `POST /api/v2/ping` (this is request 1)
+3. Receiver sends back ping response. 
+4. Sender extracts Receiver Certificate Hash from response.
+5. Receiver Hash Verification commences
+6. Both parties confirm Receiver Hash and continue. Sender pins Receiver Certificate Hash.
+8. Sender sends `POST /api/v2/register` (this is request 2)
+9. Receiver confirms PIN correct and nonce unseen. Receiver extracts Sender Certificate Hash from register request.
+10. Sender Hash Verification commences
+11. Both parties confirm Sender Hash and continue. Receiver pins Sender Certificate Hash.
+12. Receiver sends register response back to sender
+	* mTLS is now established
 
 ### Old Flow (section to be removed after new flow is finalised)
 
@@ -454,49 +524,78 @@ if !sessionValid(request.sessionID) || seen[request.nonce] {
 }
 ``` 
 
-## 6. Version negotation
+## 6. Version negotiation
 
 Offline peer-to-peer protocols provide unique opportunities for enabling long-lasting
-application lifetimes. This presents a difficult in terms of navigating incompatible versions. 
+applications. This presents a difficulty in terms of navigating incompatible versions. 
 
-Protocol version 2 is wholly incompatible with version 1 due to the introduction of compulsory mTLS.
+Protocol version 2 (this document) is wholly incompatible with version 1 due to the
+introduction of compulsory mTLS.
 
 ### Handling version 1 and version 2 incompatibility
 
-When a receiver or a sender on version 2 detects an incompatibility, they should display the
+When a receiver or a sender on version 2 detect an incompatibility, they should display the
 Incompatible Versions Message describing that the two clients can't proceed because the other
-client is running an older, incompatible version.
+client is running an older, incompatible version.  When to display the Incompatible Versions
+Message is described below.
+
+For describing senders and receivers on different version, we use the following notation:
+
+* A *sender on protocol version 2* is titled Sender-v2
+* A *receiver on protocol version 1* is titled Receiver-v1
 
 Version 1 and version 2 incompatibility can be detected in the following situations and should be
-reacted to as described:
+reacted to as described below. 
 
-1. When a version 2 sender scans a version 1 Receiver QR Code, the sender can detect the situation by
-  the lack of `protocol_version` in the Receiver QR Code. As a result, the sender should not
-  send a register request to the receiver. It should instead display the Incompatible Versions
-  Message on the sender's screen with information saying that the receiver is running an
-  older, incompatible version.
-1. A version 2 receiver that receives any requests with the route prefix `/api/v1/` should, if
-   possible, respond with a suitable error code that is known to be implemented by the version
-   1 sender. In particular:
-  1. Requests for `/api/v1/register` should return `403 Rejected` to the version 1 sender. The
-    version 2 receiver should display the Incompatible Versions Message on its screen, saying
-    that the sender was running the older version. This occurs when a version 1 sender scans a
-    version 2 Receiver QR Code.
-  1. Requests for `/api/v1/ping` should be ignored (error code 429 is not suitable). When
-     receiving version 1 ping requests and a mTLS connection has not yet been established, the
-     version 2 receiver should display the Incompatible Versions Message.
-1. A version 2 sender that sends a request to a version 1 sender will send requests to routes
-   with the prefix `/api/v2`. Requests to these routes may not receive any response. This
-   occurs when a version 2 sender tries to manually connect to a version 1 receiver i.e. it
-   concerns the *Initial Ping* used by the manual connection process.
+1. Sender-v2 scans a version 1 Receiver QR Code. The sender can detect the situation by the
+   lack of `protocol_version` in the Receiver QR Code.
+	* Sender should not send a register request to the receiver. 
+    * Sender should instead display the Incompatible Versions Message on the screen with
+      information saying that the receiver is running an older, incompatible version.
+2. Receiver-v2 receives any requests with the route prefix `/api/v1/`. It should, if
+   possible, respond with a suitable error code that is known to be implemented by a Sender-v1. In particular:
+    1. Requests for `/api/v1/register` should return `403 Rejected` to Sender-v1. Receiver-v2
+       should display the Incompatible Versions Message on its screen, saying that the sender
+       was running the older version. This occurs when a Sender-v1 scans a version 2
+       Receiver QR Code.
+    2. Requests for `/api/v1/ping` should be ignored (error code 429 is not suitable). When
+     receiving version 1 ping requests and a mTLS connection has not yet been established,
+     Receiver-v2 should display the Incompatible Versions Message.
+3. Sender-v2 sends a request to a Receiver-v1. Requests will be sent to routes with the
+   prefix `/api/v2`; requests to these routes may not receive any response. This occurs when a
+   Sender-v2 tries to manually connect to a Receiver-v1 i.e. it concerns the *Initial Ping*
+   used by the manual connection process.
       * TODO: should the handling behaviour be to have a timeout before displaying "no
         response; maybe incompatible version?" how do android/ios handle this in v1?
 
 ### How version 2 and future versions handle incompatibilities
 
+**Scanning Receiver QR code**
+
 When a sender scans a Receiver QR code and the value of field `protocol_version` is an
 unsupported version the sender should display the Incompatible Versions Message.
 
-TODO: if we describe how to handle requests for unhandled routes that could allow attacks to
-discover what protocol version (and implicit a range of versions of Tella that may be running)
-a particular receiver is running.
+**Receiving responses sent to old routes**
+
+Senders running an older protocol version should handle the following error
+code that may be sent back as a response from receivers running a newer incompatible
+version:
+
+|HTTP code|Message|
+|406|Unsupported version|
+
+As documented above in the protocol, this error code may be sent on the following routes:
+
+* `/api/v2/ping`
+* `/api/v2/register`
+
+**Responding to unhandled routes**
+
+When responding to POST requests sent to any unhandled routes, including
+unsupported version paths like `/api/v100/ping`, the receiver should send the
+following response:
+
+|HTTP code|Message|
+|--|--|
+|404|Not found|
+

--- a/README.md
+++ b/README.md
@@ -278,8 +278,8 @@ through a mix of QR code scanning and manual verification of connection
 information.  This creates the following four scenarios:
 
 * A. 100% QR flow
-* B. Receiver displays QR code + Sender Hash Verification
-* C. Sender displays QR code + Receiver Hash Verification 
+* B. Receiver QR code + Sender Hash Verification
+* C. Sender QR code + Receiver Hash Verification 
 * D. Receiver Hash Verification + Sender Hash Verification (0% QR codes)
 
 **A: Receiver can scan / Sender can scan (100% QR flow)**

--- a/README.md
+++ b/README.md
@@ -277,10 +277,10 @@ Connection establishment and exchange of certification information can be done
 through a mix of QR code scanning and manual verification of connection
 information.  This creates the following four scenarios:
 
-A. 100% QR flow
-B. Receiver displays QR code + Sender Hash Verification
-C. Sender displays QR code + Receiver Hash Verification 
-D. Receiver Hash Verification + Sender Hash Verification (0% QR codes)
+* A. 100% QR flow
+* B. Receiver displays QR code + Sender Hash Verification
+* C. Sender displays QR code + Receiver Hash Verification 
+* D. Receiver Hash Verification + Sender Hash Verification (0% QR codes)
 
 **A: Receiver can scan / Sender can scan (100% QR flow)**
 

--- a/README.md
+++ b/README.md
@@ -222,12 +222,12 @@ For this flow we use the notation Device A (sender) and Device B (receiver).
 
 **Step 1: Pin receiver certificate**
 
-When sender can scan receiver QR codes: 
+When sender can scan Receiver QR code: 
 
 * Device B (receiver) presents QR code containing information outlined in *2.1.1 Receiver QR code*
 * Device A (sender) scans QR code, parses information, and pins the embedded Receiver Certificate Hash
 
-When sender cannot scan receiver QR codes (broken screen/camera or comms with desktop):
+When sender cannot scan Receiver QR code (broken screen/camera or comms with desktop):
 
 * Device B (receiver) displays manual connection info outlined in *2.2- Manual authentication (Fallback Method)*
 * Device A (sender) types in manual connection info and sends ping request outlined in *3.1 Initial Ping*
@@ -247,7 +247,7 @@ Certificate Hash.
 
 **Step 2: Pin sender certificate**
 
-When receiver can scan sender QR codes: 
+When receiver can scan Sender QR code: 
 
 * Device A (sender) presents QR code containing the sender's certificate hash outlined in *2.1.2 Sender QR code*
 * Device B (receiver) scans QR code, parses information, and pins the embedded Sender Certificate Hash
@@ -255,7 +255,7 @@ When receiver can scan sender QR codes:
 * Device B (receiver) processes registration request, making sure that PIN is correct and nonce has not been seen
 * Finalise registration. Mutual TLS has been established, proceed to *4.1 Prepare upload*
 
-When receiver cannot scan sender QR codes (broken screen/camera or comms with desktop):
+When receiver cannot scan Sender QR code (broken screen/camera or comms with desktop):
 
 * Device A (sender) sends register request payload outlined in *3.2- Initial Registration*
 * Device A (sender) displays the hash of their TLS certificate
@@ -285,14 +285,14 @@ information.  This creates the following four scenarios:
 **A: Receiver can scan / Sender can scan (100% QR flow)**
 
 1. Receiver scans Sender QR Code (no requests have been sent). Receiver pins Sender Certificate Hash.
-2. Sender scans Receiver QR Code (still no requests have been sent). Sender pins Receiver Certificate Hash.
+2. Sender scans Receiver QR code (still no requests have been sent). Sender pins Receiver Certificate Hash.
    * mTLS is now established
 3. Sender sends `POST /api/v2/register` (this is request 1)
 
 **B: Receiver cannot scan / Sender can scan flow (Sender Hash Verification)**
 
 1. Receiver marks that they can't scan QR codes
-2. Sender scans Receiver QR Code (no requests have been sent). Sender pins Receiver Certificate Hash.
+2. Sender scans Receiver QR code (no requests have been sent). Sender pins Receiver Certificate Hash.
 3. Sender sends `POST /api/v2/register` (this is request 1)
 4. Receiver confirms PIN correct and nonce unseen. Receiver extracts Sender Certificate Hash from register request.
 5. Sender Hash Verification commences
@@ -547,8 +547,8 @@ For describing senders and receivers on different version, we use the following 
 Version 1 and version 2 incompatibility can be detected in the following situations and should be
 reacted to as described below. 
 
-1. Sender-v2 scans a version 1 Receiver QR Code. The sender can detect the situation by the
-   lack of `protocol_version` in the Receiver QR Code.
+1. Sender-v2 scans a version 1 Receiver QR code. The sender can detect the situation by the
+   lack of `protocol_version` in the Receiver QR code.
 	* Sender should not send a register request to the receiver. 
     * Sender should instead display the Incompatible Versions Message on the screen with
       information saying that the receiver is running an older, incompatible version.
@@ -557,7 +557,7 @@ reacted to as described below.
     1. Requests for `/api/v1/register` should return `403 Rejected` to Sender-v1. Receiver-v2
        should display the Incompatible Versions Message on its screen, saying that the sender
        was running the older version. This occurs when a Sender-v1 scans a version 2
-       Receiver QR Code.
+       Receiver QR code.
     2. Requests for `/api/v1/ping` should be ignored (error code 429 is not suitable). When
      receiving version 1 ping requests and a mTLS connection has not yet been established,
      Receiver-v2 should display the Incompatible Versions Message.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ QR payload:
   certificate_hash: String,
   pin: String,
   protocol_version: Number,
-  sender_show_hash: Booolean
+  sender_show_hash: Boolean
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ Self-signed TLS certificates are generated and used on both sides of the connect
 establish a mutual TLS (mTLS) connection: the sender verifies the receiver, and
 the receiver verifies the sender.
 
-In this document we call the fingerprint identifying the sender's certificate as the Sender
-Certificate Hash. In the same way the receiver's certificate is identified by the Receiver
-Certificate Hash.
+Certificate verification is done by comparing certificate fingerprints on both sides of the
+connection. The fingerprints are derived by SHA256-hashing certificate information and
+representing the resulting hash as a hexadecimal string. Accordingly in this document we call
+the fingerprint identifying the sender's certificate the Sender Certificate Hash. In the
+same way the receiver's certificate is identified by the Receiver Certificate Hash.
 
 Certificates are generated and used per session, being discarded when a session ends.
 

--- a/README.md
+++ b/README.md
@@ -210,8 +210,8 @@ When sender cannot scan QR codes (broken screen/camera or comms with desktop):
 * Device B (receiver) displays the hash of their TLS certificate
 * Device A (sender) extracts the receiver's certificate information from the connection info for the ping
   response, hashes it, and displays the Receiver Certificate Hash
-* Device A (sender) and receiver visually compare the hashes as outlined in *2.3- Verification screen*
-* If verification succeds, the sender pins the Receiver Certificate Hash
+* Device A (sender) and Device B (receiver) visually compare the hashes as outlined in *2.3- Verification screen*
+* If verification succeds, Device A (sender) pins the Receiver Certificate Hash
 * Proceed to step 2
 
 After Device A (sender) has pinned Receiver Certificate Hash, Device A (sender)
@@ -237,8 +237,8 @@ When receiver cannot scan QR codes (broken screen/camera or comms with desktop):
 * Device B (receiver) processes registration request, making sure that PIN is correct and nonce has not
   been seen (**Note:** this must happen before extracting certificate information in next step)
 * Device B (receiver) extracts the sender's certificate information from the connection info of the registration request, hashes it, and displays the Sender Certificate Hash
-* Device A (sender) and receiver visually compare the hashes as outlined in *2.3- Verification screen*
-* If verification succeds, the receiver pins the Sender Certificate Hash
+* Device A (sender) and Device B (receiver) visually compare the hashes as outlined in *2.3- Verification screen*
+* If verification succeds, Device B (receiver) pins the Sender Certificate Hash
 * Finalise registration. Mutual TLS has been established, proceed to *4.1 Prepare upload*
 
 After Device B (receiver) has pinned the Sender Certificate Hash, Device B

--- a/README.md
+++ b/README.md
@@ -73,24 +73,18 @@ The receiver device displays a QR code containing:
 * Receiver Certificate Hash
 * Connection PIN
 * Protocol version number
-* Whether sender in step 2 of section *New flow* should directly show hash verification
 
 QR payload:
 
 ```json5
 {
-  ip_address: [String, ..., ..., String],
-  port: Number,
-  certificate_hash: String,
-  pin: String,
-  protocol_version: Number,
-  sender_show_hash: Boolean
+  "ip_address": [String, ..., ..., String],
+  "port": Number,
+  "certificate_hash": String,
+  "pin": String,
+  "protocol_version": Number
 }
 ```
-
-If for example the receiver is a desktop client, `sender_show_hash` should be set to `true` and
-sender in step 2 in section *New flow* should skip display of the QR code and directly show the
-hash verification screen.
 
 For the protocol described in the current document, the protocol version should be set to
 `protocol_version: 2`
@@ -108,7 +102,7 @@ QR payload:
 
 ```json5
 {
-  certificate_hash: String
+  "certificate_hash": String
 }
 ```
 
@@ -154,11 +148,15 @@ This endpoint initiates a secure handshake between two devices during the manual
 
 Response payload
 
-```markdown
+```json5
 {
-  "senderShowHash": boolean
+  "senderShowHash": Boolean
 }
 ```
+
+If for example the receiver is a desktop client, `senderShowHash` should be set to `true` and
+sender in step 2 in section *New flow* should skip display of the QR code and directly show the
+hash verification screen.
 
 Errors:
 
@@ -191,17 +189,17 @@ response should also be rejected.
 
 Request payload
 
-```markdown 
+```json5 
 {
-  pin: "123456",
-  nonce: "random-uuid-number",
+  "pin": "123456",
+  "nonce": "random-uuid-number",
 }
 ```
 
 
 Response payload
 
-```markdown
+```json5
 {
   "sessionId": "uuid-session-identifier"
 }
@@ -534,8 +532,8 @@ if !sessionValid(request.sessionID) || seen[request.nonce] {
 Offline peer-to-peer protocols provide unique opportunities for enabling long-lasting
 applications. This presents a difficulty in terms of navigating incompatible versions. 
 
-Protocol version 2 (this document) is wholly incompatible with version 1 due to the
-introduction of compulsory mTLS.
+Protocol version 2 (this document) is wholly incompatible with version 1 (previous version of
+this document) due to the introduction of compulsory mTLS.
 
 ### Handling version 1 and version 2 incompatibility
 
@@ -552,17 +550,17 @@ For describing senders and receivers on different version, we use the following 
 Version 1 and version 2 incompatibility can be detected in the following situations and should be
 reacted to as described below. 
 
-1. Sender-v2 scans a version 1 Receiver QR code. The sender can detect the situation by the
-   lack of `protocol_version` in the Receiver QR code.
+1. Sender-v2 scans a Receiver-v1 QR code. The sender can detect the situation by the
+   lack of `protocol_version` in the Receiver-v1 QR code.
 	* Sender should not send a register request to the receiver. 
     * Sender should instead display the Incompatible Versions Message on the screen with
       information saying that the receiver is running an older, incompatible version.
-2. Receiver-v2 receives any requests with the route prefix `/api/v1/`. It should, if
-   possible, respond with a suitable error code that is known to be implemented by a Sender-v1. In particular:
+2. Receiver-v2 receives any requests with the route prefix `/api/v1/` for known routes (ping,
+   register). The receiver should, if possible, respond with a suitable error code that is
+   known to be implemented by a Sender-v1. In particular:
     1. Requests for `/api/v1/register` should return `403 Rejected` to Sender-v1. Receiver-v2
        should display the Incompatible Versions Message on its screen, saying that the sender
-       was running the older version. This occurs when a Sender-v1 scans a version 2
-       Receiver QR code.
+       was running the older version. This occurs when a Sender-v1 scans a Receiver-v2 QR code.
     2. Requests for `/api/v1/ping` should be ignored (error code 429 is not suitable). When
      receiving version 1 ping requests and a mTLS connection has not yet been established,
      Receiver-v2 should display the Incompatible Versions Message.

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ This repository describes the peer-to-peer file sharing protocol implemented by 
 
 
 ## Platform and availability
-Nearby Sharing will be available for [Tella Android](https://github.com/Horizontal-org/Tella-Android), [Tella iOS](https://github.com/Horizontal-org/Tella-iOS) and [Tella Desktop](https://github.com/Horizontal-org/Tella-Desktop), but it's still under development.
+Nearby Sharing is available for [Tella Android](https://github.com/Horizontal-org/Tella-Android), [Tella iOS](https://github.com/Horizontal-org/Tella-iOS) and [Tella Desktop](https://github.com/Horizontal-org/Tella-Desktop).
 
-The feature is still in alpha, and it's currently being audited by an independent security firm. It will be launched to production only after the priority security fixes are implemented.
+The feature has been audited by an independent security firm.
 
-User facing documentation about the feature is available here: https://beta.tella-app.org/nearby-sharing
+User facing documentation about the feature is available here: https://tella-app.org/nearby-sharing
 
 ## Credits
 This protocol (and Nearby Sharing feature in Tella in general) is inspired by the [LocalSend project](https://github.com/localsend/localsend), and it uses the local network Wi-Fi without needing an internet connection. 
@@ -44,10 +44,10 @@ the receiver verifies the sender.
 
 Certificate verification is done by comparing certificate fingerprints on both sides of the
 connection. The fingerprints are derived by SHA256-hashing the raw bytes of the certificate
-attached to a request/response and representing the resulting hash as a hexadecimal string.
-Accordingly in this document we call the fingerprint identifying the sender's certificate the
-Sender Certificate Hash. In the same way the receiver's certificate is identified by the
-Receiver Certificate Hash.
+information attached to a request/response and representing the resulting hash as a hexadecimal
+string.  Accordingly in this document we call the fingerprint identifying the sender's
+certificate the Sender Certificate Hash. In the same way the receiver's certificate is
+identified by the Receiver Certificate Hash.
 
 Certificates are generated and used per session, being discarded when a session ends.
 
@@ -65,7 +65,7 @@ Requests for unknown or concluded transfer sessions should be rejected.
 
 ### 2.1- QR authentication (primary method)
 
-#### 2.1.1 Receiver QR code
+#### 2.1.1- Receiver QR code
 
 The receiver device displays a QR code containing:
 
@@ -93,7 +93,7 @@ For the protocol described in the current document, the protocol version should 
 **Note:** `ip_address` is a list of strings, as the receiver may have many different local IP
 addresses.
 
-#### 2.1.2 Sender QR code
+#### 2.1.2- Sender QR code
 
 The sender device displays a QR code containing:
 
@@ -122,7 +122,7 @@ After entering the connection information, both the sender and the receiver will
 When manually verifying a certificate on either side of the connection, both sender and
 receiver will display a verification screen containing an alphanumeric sequence that encodes
 the certificate hash being verified (either Receiver Certificate Hash or Sender Certificate
-Hash, depending on the steps outlined in section *Flow*).
+Hash, depending on the steps outlined in section *3.2.1- Flow*).
 
 Both parties will verify that the same sequence is shown on each device before proceeding.
 
@@ -161,7 +161,7 @@ Response payload
 ```
 
 If for example the receiver is a desktop client, `senderShowHash` should be set to `true` and
-sender in step 2 in section *Flow* should skip display of the QR code and directly show the
+sender in step 2 in section *3.2.1- Flow* should skip display of the QR code and directly show the
 hash verification screen.
 
 Errors:
@@ -225,7 +225,7 @@ Errors:
 |429|Too many requests|
 |500|Server error|
 
-#### Flow
+#### 3.2.1- Flow
 
 The security of mTLS amounts to each side of a connection being secured by a TLS certificate
 belonging to an authorized party. Since this protocol relies on the use of self-signed
@@ -268,7 +268,7 @@ Certificate Hash.
 
 When Device B (receiver) can scan Sender QR code: 
 
-* Device A (sender) presents QR code containing the sender's certificate hash outlined in *2.1.2 Sender QR code*.
+* Device A (sender) presents QR code containing the sender's certificate hash outlined in *2.1.2- Sender QR code*.
 * Device B (receiver) scans QR code, parses information, and pins the embedded Sender Certificate Hash.
 * Device A (sender) sends register request payload outlined in *3.2- Initial Registration*.
 * Device B (receiver) processes registration request, making sure that PIN is correct and nonce has not been seen.
@@ -290,7 +290,7 @@ After Device B (receiver) has pinned the Sender Certificate Hash, Device B
 request sent after register, Device B (receiver) hashes the certificate information from
 the connection and checks the computed hash against the pinned Sender Certificate Hash.
 
-#### Connection scenarios
+#### 3.2.2- Connection scenarios
 
 Connection establishment and exchange of certification information can be done
 through a mix of QR code scanning and manual verification of connection
@@ -548,8 +548,6 @@ reacted to as described below.
    prefix `/api/v2`; requests to these routes may not receive any response. This occurs when a
    Sender-v2 tries to manually connect to a Receiver-v1 i.e. it concerns the *Initial Ping*
    used by the manual connection process.
-      * TODO: should the handling behaviour be to have a timeout before displaying "no
-        response; maybe incompatible version?" how do android/ios handle this in v1?
 
 ### How version 2 and future versions handle incompatibilities
 

--- a/README.md
+++ b/README.md
@@ -118,12 +118,17 @@ After entering the connection information, both the sender and the receiver will
 
 ### 2.3- Verification screen
 
-Both the sender and the receiver will display a verification screen containing an alphanumeric sequence that encodes the hash of the receiver's TLS certificate.
+When manually verifying a certificate on either side of the connection, both sender and
+receiver will display a verification screen containing an alphanumeric sequence that encodes
+the certificate hash being verified (either Receiver Certificate Hash or Sender Certificate
+Hash, depending on the steps outlined in section *Flow*).
 
 Both parties will verify that the same sequence is shown on each device before proceeding.
 
 The verification screen will provide two options:
-* Confirm and Connect — Proceed with registration if the hashes match.
+
+* Confirm and Continue — Proceed with registration if the hashes match.
+    * Note: The label is *Confirm and Connect* for receiver when verifying Sender Certificate Hash.
 * Discard and Start Over — Terminate the connection and the user should be returned to the main connection screen.
 
 Example of alphanumeric sequence (SHA-256 hash):
@@ -155,7 +160,7 @@ Response payload
 ```
 
 If for example the receiver is a desktop client, `senderShowHash` should be set to `true` and
-sender in step 2 in section *New flow* should skip display of the QR code and directly show the
+sender in step 2 in section *Flow* should skip display of the QR code and directly show the
 hash verification screen.
 
 Errors:
@@ -219,28 +224,38 @@ Errors:
 |429|Too many requests|
 |500|Server error|
 
-#### New flow
+#### Flow
 
-For this flow we use the notation Device A (sender) and Device B (receiver).
+The security of mTLS amounts to each side of a connection being secured by a TLS certificate
+belonging to an authorized party. Since this protocol relies on the use of self-signed
+certificates, the certificates have to be verified. In this protocol, verification is done
+either automatically (out-of-band QR code transmission of certificate fingerprint) or through
+manual visual inspection of a certificate fingerprint. Once a certificate has been verified,
+the fingerprint is saved and used to compare against future traffic, verifying the traffic
+originated from the same host possessing the certificate. In this section we describe the
+details of the two steps when fingerprint pinning occurs.
+
+In order to best describe the flow of actions of the different devices, we use the notation
+Device A (sender) and Device B (receiver).
 
 **Step 1: Pin Receiver Certificate Hash**
 
-When sender can scan Receiver QR code: 
+When Device A (sender) can scan Receiver QR code: 
 
-* Device B (receiver) presents QR code containing information outlined in *2.1.1 Receiver QR code*
-* Device A (sender) scans QR code, parses information, and pins the embedded Receiver Certificate Hash
+* Device B (receiver) presents QR code containing information outlined in *2.1.1 Receiver QR code*.
+* Device A (sender) scans QR code, parses information, and pins the embedded Receiver Certificate Hash.
 
-When sender cannot scan Receiver QR code (broken screen/camera or comms with desktop):
+When Device A (sender) cannot scan Receiver QR code (broken screen/camera or comms with desktop):
 
-* Device B (receiver) displays manual connection info outlined in *2.2- Manual authentication (Fallback Method)*
-* Device A (sender) types in manual connection info and sends ping request outlined in *3.1 Initial Ping*
-* Device B (receiver) sends response to ping request
-* Device B (receiver) displays the hash of their TLS certificate
-* Device A (sender) extracts the receiver's certificate information from the connection info for the ping
-  response, hashes it, and displays the Receiver Certificate Hash
-* Device A (sender) and Device B (receiver) visually compare the hashes as outlined in *2.3- Verification screen*
-* If verification succeds, Device A (sender) pins the Receiver Certificate Hash
-* Proceed to step 2
+* Device B (receiver) displays manual connection info outlined in *2.2- Manual authentication (Fallback Method)*.
+* Device A (sender) types in manual connection info and sends ping request outlined in *3.1 Initial Ping*.
+* Device B (receiver) sends response to ping request.
+* Device B (receiver) displays the hash of their TLS certificate.
+* Device A (sender) extracts the receiver's certificate information from the connection info for the ping.
+  response, hashes it, and displays the Receiver Certificate Hash.
+* Device A (sender) and Device B (receiver) visually compare the hashes as outlined in *2.3- Verification screen*.
+* If verification succeds, Device A (sender) pins the Receiver Certificate Hash.
+* Proceed to step 2.
 
 After Device A (sender) has pinned Receiver Certificate Hash, Device A (sender)
 will compute each certificate hash on all future responses. For each response
@@ -250,124 +265,89 @@ Certificate Hash.
 
 **Step 2: Pin Sender Certificate Hash**
 
-When receiver can scan Sender QR code: 
+When Device B (receiver) can scan Sender QR code: 
 
-* Device A (sender) presents QR code containing the sender's certificate hash outlined in *2.1.2 Sender QR code*
-* Device B (receiver) scans QR code, parses information, and pins the embedded Sender Certificate Hash
-* Device A (sender) sends register request payload outlined in *3.2- Initial Registration*
-* Device B (receiver) processes registration request, making sure that PIN is correct and nonce has not been seen
-* Finalise registration. Mutual TLS has been established, proceed to *4.1 Prepare upload*
+* Device A (sender) presents QR code containing the sender's certificate hash outlined in *2.1.2 Sender QR code*.
+* Device B (receiver) scans QR code, parses information, and pins the embedded Sender Certificate Hash.
+* Device A (sender) sends register request payload outlined in *3.2- Initial Registration*.
+* Device B (receiver) processes registration request, making sure that PIN is correct and nonce has not been seen.
+* Finalise registration. Proceed to *4.1 Prepare upload*.
 
-When receiver cannot scan Sender QR code (broken screen/camera or comms with desktop):
+When Device B (receiver) cannot scan Sender QR code (broken screen/camera or comms with desktop):
 
-* Device A (sender) sends register request payload outlined in *3.2- Initial Registration*
-* Device A (sender) displays the hash of their TLS certificate
-* Device B (receiver) processes registration request, making sure that PIN is correct and nonce has not
-  been seen (**Note:** this must happen before extracting certificate information in next step)
-* Device B (receiver) extracts the sender's certificate information from the connection info of the registration request, hashes it, and displays the Sender Certificate Hash
-* Device A (sender) and Device B (receiver) visually compare the hashes as outlined in *2.3- Verification screen*
-* If verification succeds, Device B (receiver) pins the Sender Certificate Hash
-* Finalise registration. Mutual TLS has been established, proceed to *4.1 Prepare upload*
+* Device A (sender) sends register request payload outlined in *3.2- Initial Registration*.
+* Device A (sender) displays the hash of their TLS certificate.
+* Device B (receiver) processes registration request, making sure that PIN is correct and nonce has not.
+  been seen (**Note:** this must happen before extracting certificate information in next
+  step).
+* Device B (receiver) extracts the sender's certificate information from the connection info of the registration request, hashes it, and displays the Sender Certificate Hash.
+* Device A (sender) and Device B (receiver) visually compare the hashes as outlined in *2.3- Verification screen*.
+* If verification succeds, Device B (receiver) pins the Sender Certificate Hash.
+* Finalise registration. Proceed to *4.1 Prepare upload*.
 
 After Device B (receiver) has pinned the Sender Certificate Hash, Device B
 (receiver) will compute each certificate hash on all future requests. For each
 request sent after register, Device B (receiver) hashes the certificate information from
 the connection and checks the computed hash against the pinned Sender Certificate Hash.
 
-##### Connection scenarios
+#### Connection scenarios
 
 Connection establishment and exchange of certification information can be done
 through a mix of QR code scanning and manual verification of connection
-information.  This creates the following four scenarios:
+information. This creates the following four scenarios:
 
 * A. 100% QR flow
 * B. Receiver QR code + Sender Hash Verification
 * C. Sender QR code + Receiver Hash Verification 
 * D. Receiver Hash Verification + Sender Hash Verification (0% QR codes)
 
+As described in section *2.3- Verification screen*, at any point during a hash verification
+either side can discard and sever the connection if a hash is not matching what is displayed on
+the other device.
+
 **A: Receiver can scan / Sender can scan (100% QR flow)**
 
 1. Receiver scans Sender QR code (no requests have been sent). Receiver pins Sender Certificate Hash.
 2. Sender scans Receiver QR code (still no requests have been sent). Sender pins Receiver Certificate Hash.
-   * mTLS is now established
-3. Sender sends `POST /api/v2/register` (this is request 1)
+   * mTLS is now established.
+3. Sender sends `POST /api/v2/register` (this is request 1).
 
-**B: Receiver cannot scan / Sender can scan flow (Sender Hash Verification)**
+**B: Receiver cannot scan / Sender can scan (Sender Hash Verification)**
 
-1. Receiver marks that they can't scan QR codes
+1. Receiver marks that they can't scan QR codes.
 2. Sender scans Receiver QR code (no requests have been sent). Sender pins Receiver Certificate Hash.
-3. Sender sends `POST /api/v2/register` (this is request 1)
+3. Sender sends `POST /api/v2/register` (this is request 1).
 4. Receiver confirms PIN correct and nonce unseen. Receiver extracts Sender Certificate Hash from register request.
-5. Sender Hash Verification commences
+5. Sender Hash Verification commences.
 6. Both parties confirm Sender Hash and continue. Receiver pins Sender Certificate Hash.
-   * mTLS is now established
-7. Receiver sends register response back to sender
+   * mTLS is now established.
+7. Receiver sends register response back to sender.
 
-**C: Receiver can scan / Sender cannot scan flow (Receiver Hash Verification)**
+**C: Receiver can scan / Sender cannot scan (Receiver Hash Verification)**
 
 1. Receiver scans Sender QR code (no requests have been sent). Receiver pins Sender Certificate Hash.
-2. Sender does manual connection, types in Receiver IP Address, PIN, Port. Sender sends `POST /api/v2/ping` (this is request 1)
+2. Sender does manual connection, types in Receiver IP Address, PIN, Port. Sender sends `POST /api/v2/ping` (this is request 1).
 3. Receiver sends back ping response. 
 4. Sender extracts Receiver Certificate Hash from ping response.
-5. Receiver Hash Verification commences
+5. Receiver Hash Verification commences.
 6. Both parties confirm Receiver Hash and continue. Sender pins Receiver Certificate Hash.
-   *  mTLS is now established
-7. Sender sends `POST /api/v2/register` (this is request 2)
+   *  mTLS is now established.
+7. Sender sends `POST /api/v2/register` (this is request 2).
 
-**D: Receiver cannot scan / Sender cannot scan flow (Receiver Hash Verification and Sender Hash Verification)**:
+**D: Receiver cannot scan / Sender cannot scan (Receiver Hash Verification and Sender Hash Verification; 0% QR codes)**
 
-1. Receiver marks that they can't scan QR codes
-2. Sender does manual connection, types in Receiver IP Address, PIN, Port. Sender sends `POST /api/v2/ping` (this is request 1)
+1. Receiver marks that they can't scan QR codes.
+2. Sender does manual connection, types in Receiver IP Address, PIN, Port. Sender sends `POST /api/v2/ping` (this is request 1).
 3. Receiver sends back ping response. 
 4. Sender extracts Receiver Certificate Hash from response.
-5. Receiver Hash Verification commences
+5. Receiver Hash Verification commences.
 6. Both parties confirm Receiver Hash and continue. Sender pins Receiver Certificate Hash.
-8. Sender sends `POST /api/v2/register` (this is request 2)
+8. Sender sends `POST /api/v2/register` (this is request 2).
 9. Receiver confirms PIN correct and nonce unseen. Receiver extracts Sender Certificate Hash from register request.
-10. Sender Hash Verification commences
+10. Sender Hash Verification commences.
 11. Both parties confirm Sender Hash and continue. Receiver pins Sender Certificate Hash.
-12. Receiver sends register response back to sender
-	* mTLS is now established
-
-### Old Flow (section to be removed after new flow is finalised)
-
-**QR Code Method:**
-
-- Device A (sender) scans the QR code containing:
-    - Device B's IP address
-    - Port
-    - Receiver Certificate Hash
-    - PIN
-- Device A (sender) pins Receiver Certificate Hash
-- Device A (sender) sends a payload to `/api/v2/register` containing:
-    - PIN
-    - Nonce
-- Device B (recipient) receives the payload
-- Device B (recipient) checks PIN code is valid 
-- Device B (recipient) returns the `sessionId`
-
-After Device A (sender) has pinned Receiver Certificate Hash from the QR code,
-Device A (sender) will independently compute each certificate hash on future responses
-sent from Device B (recipient). For each response sent by Device B (recipient),
-Device A (sender) hashes the certificate from the connection and checks the
-computed hash against the Receiver Certificate Hash pinned from the QR code.
-
-**Manual Method:**
-
-Initial Ping:
-- Device A (sender) manually types the IP address, PIN, and port
-- Device A (sender) sends a ping to `/api/v2/ping`
-- Device A (sender) retrieves the Receiver Certificate Hash from recipient 
-- Device A (sender) displays the Receiver Certificate Hash to be compared  
-- Device B (recipient) displays the Receiver Certificate Hash upon receiving the `/api/v2/ping` request
-    
-Initial Registration:
-- After confirming the Receiver Certificate Hash, Device A (sender) sends the payload to `/api/v2/register`
-    - PIN
-    - Nonce
-- Device B (recipient) receives the payload
-- Device B (recipient) checks PIN code is valid
-- Device B (recipient) returns the `sessionId`
+	* mTLS is now established.
+12. Receiver sends register response back to sender.
 
 ## 4- File Transfer
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ QR payload:
 }
 ```
 
+For the protocol described in the current document, the protocol version should be set to
+`protocol_version: 2`
+
 **Note:** `ip_address` is a list of strings, as the receiver may have many different local IP
 addresses.
 


### PR DESCRIPTION
This PR introduces compulsory mTLS into the Tella P2P Protocol. Among the described is a flow where it is possible for both sides of the connection to be secured by scanning QR codes to pass certificate information (mobile only). 

We outline different connection scenarios ranging from 100% QR code use to 0% QR code use (aka manual connection) and hybrids of QR + manual. We have tried to strike a balance between being explicit, such as enumerating various connection scenarios, so as to align the behaviours of the different implementations, and also limiting established terms and trying to avoid overflowing the document with extraneous information.

Since protocol version 2 is incompatible with the previously published Tella P2P Protocol version (retroactively titled protocol version 1) we have added descriptions on how to handle the version 1 and version 2 incompatibility, as well as described how to handle incompatibility from version 2 and going into the future.